### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ jobs:
   delete-package-versions:
     name: Delete package versions older than 4 weeks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: snok/container-retention-policy@v3.0.0
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/mediathekcommunity/website/security/code-scanning/7](https://github.com/mediathekcommunity/website/security/code-scanning/7)

To fix the issue, add a `permissions` block to the workflow to explicitly define the required permissions for the `GITHUB_TOKEN`. Since the workflow interacts with package versions, it likely requires `contents: read` to access repository contents and possibly `packages: write` to delete old package versions. These permissions should be set at the job level to ensure they are scoped to the specific task.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to improve security and ensure proper access for package management tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->